### PR TITLE
Throw new exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: "22.3.0"
     hooks:
       - id: black
         language_version: python3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="tink-http-python",
-    version="0.0.8",
+    version="0.0.9",
     description="Python SDK for accessing the tink API ",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tink_http_python/authentication/api.py
+++ b/tink_http_python/authentication/api.py
@@ -6,7 +6,6 @@ class Api:
         self.api = api
 
     def refresh_token(self, client_id, client_secret, token) -> dict:
-
         return self.api.post(
             "oauth/token",
             {},
@@ -19,7 +18,6 @@ class Api:
         )
 
     def get_new_access_token(self, client_id, client_secret, code) -> dict:
-
         return self.api.post(
             "oauth/token",
             {},

--- a/tink_http_python/authentication/authentication.py
+++ b/tink_http_python/authentication/authentication.py
@@ -1,6 +1,7 @@
 from .storage import Storage
 from tink_http_python.api import ApiV1
 from tink_http_python.config import Config
+from tink_http_python.exceptions import NoAuthorizationCodeException
 from .api import Api
 
 
@@ -10,16 +11,15 @@ class Authentication:
         self.api = Api(api)
         self.config = config
 
-    def _get_tink_link(self):
+    @staticmethod
+    def get_authorization_code_link(self):
         return f"https://link.tink.com/1.0/transactions/connect-accounts/?client_id={self.config.client_id}&redirect_uri=https%3A%2F%2Fconsole.tink.com%2Fcallback&market=ES&locale=es_ES"
 
     def get_refresh_token(self) -> str:
         try:
             code = self.storage.retrieve_authorization_code()
         except FileNotFoundError:
-            print("Get a code from this link and save it as authorization_code:")
-            print(self._get_tink_link())
-            exit()
+            raise NoAuthorizationCodeException
         token_response = self.api.get_new_access_token(
             self.config.client_id, self.config.client_secret, code
         )

--- a/tink_http_python/exceptions.py
+++ b/tink_http_python/exceptions.py
@@ -1,0 +1,2 @@
+class NoAuthorizationCodeException(Exception):
+    pass

--- a/tink_http_python/tink.py
+++ b/tink_http_python/tink.py
@@ -20,3 +20,6 @@ class Tink:
 
     def transactions(self):
         return self._transactions
+
+    def get_authorization_code_link(self):
+        return self._authentication.get_authorization_code_link()


### PR DESCRIPTION
When the authorization code is not present, instead of printing the link throw an exception.
Then expose a method to ask for it.